### PR TITLE
排他グループを選択してv2モードでない場合に初期状態が反映されない問題、および別インスタンスに設定が反映されない問題を修正。

### DIFF
--- a/Assets/YagihataItems/RadialInventorySystemV3/Editor/RISGimmickBuilder.cs
+++ b/Assets/YagihataItems/RadialInventorySystemV3/Editor/RISGimmickBuilder.cs
@@ -754,7 +754,7 @@ namespace YagihataItems.RadialInventorySystemV3
                     var prop = group.Props[propIndex];
                     var v2Mode = false;
                     if ((variables.MenuMode == RISV3.RISMode.Simple && group.ExclusiveMode == 3) ||
-                        (variables.MenuMode == RISV3.RISMode.Advanced && prop.PropGroupType != RISV3.PropGroup.None))
+                        (variables.MenuMode == RISV3.RISMode.Advanced && prop.PropGroupType != RISV3.PropGroup.None && variables.AdvancedGroupMode[(int)prop.PropGroupType] == 1))
                         v2Mode = true;
                     TryAddParam(variables, $"RISV3-G{groupIndex}P{propIndex}", prop.IsDefaultEnabled && !v2Mode ? 1f : 0f, prop.SaveParameter);
                 }

--- a/Assets/YagihataItems/RadialInventorySystemV3/Script/Prop.cs
+++ b/Assets/YagihataItems/RadialInventorySystemV3/Script/Prop.cs
@@ -41,14 +41,12 @@ namespace YagihataItems.RadialInventorySystemV3
             TargetObject = gameObject;
             IsDefaultEnabled = false;
             PropIcon = null;
-            TargetObjects.Add(null);
         }
         public Prop()
         {
             TargetObject = null;
             IsDefaultEnabled = false;
             PropIcon = null;
-            TargetObjects.Add(null);
         }
         public string GetPropName(RISV3.RISMode menuMode)
         {
@@ -66,7 +64,7 @@ namespace YagihataItems.RadialInventorySystemV3
         }
         public object Clone()
         {
-            var obj = new Prop(TargetObject);
+            var obj = ScriptableObject.CreateInstance<Prop>();
             obj.IsDefaultEnabled = this.IsDefaultEnabled;
             obj.PropIcon = this.PropIcon;
             obj.LocalOnly = this.LocalOnly;

--- a/Assets/YagihataItems/RadialInventorySystemV3/Script/PropGroup.cs
+++ b/Assets/YagihataItems/RadialInventorySystemV3/Script/PropGroup.cs
@@ -32,7 +32,7 @@ namespace YagihataItems.RadialInventorySystemV3
         }
         public object Clone()
         {
-            var obj = new PropGroup();
+            var obj = ScriptableObject.CreateInstance<PropGroup>();
             obj.GroupName = this.GroupName;
             obj.GroupIcon = this.GroupIcon;
             obj.ExclusiveMode = this.ExclusiveMode;

--- a/Assets/YagihataItems/RadialInventorySystemV3/Script/RISSettings.cs
+++ b/Assets/YagihataItems/RadialInventorySystemV3/Script/RISSettings.cs
@@ -17,7 +17,7 @@ namespace YagihataItems.RadialInventorySystemV3
         [SerializeField] public string FolderID { get { return risVariables.FolderID; } set { risVariables.FolderID = value; } }
         [SerializeField] public List<PropGroup> Groups { get { return risVariables.Groups; } set { risVariables.Groups = value; } }
 
-        [SerializeField] [HideInInspector] public RISVariables risVariables = new RISVariables();
+        [SerializeField] /*[HideInInspector]*/ public RISVariables risVariables = new RISVariables();
         [SerializeField] public RISV3.RISMode MenuMode { get { return risVariables.MenuMode; } set { risVariables.MenuMode = value; } }
         [SerializeField] public bool ApplyEnabled { get { return risVariables.ApplyEnabled; } set { risVariables.ApplyEnabled = value; } }
         [SerializeField] public int[] AdvancedGroupMode { get { return risVariables.AdvancedGroupMode; } set { risVariables.AdvancedGroupMode = value; } }


### PR DESCRIPTION
#5 の排他グループの初期状態がおかしくなるのは、v2モードかどうかのチェックに不備があることが原因でした。
また、保存された設定を同じ名前の別インスタンスのAvatarRootで設定を読み込むとTargetObjectsの参照先は別インスタンスとなっているためNullとなってしまう問題を修正しました。