### PR TITLE
SimpleモードでのTargetObject再割り当ての追加。

### DIFF
--- a/Assets/YagihataItems/RadialInventorySystemV3/Editor/RISMainWindow.cs
+++ b/Assets/YagihataItems/RadialInventorySystemV3/Editor/RISMainWindow.cs
@@ -254,7 +254,7 @@ namespace YagihataItems.RadialInventorySystemV3
                         if(variables.Groups[groupIndex] == null)
                         {
                             EditorUtility.DisplayDialog("Radial Inventory System", $"グループ{groupIndex}が破損していたため、\r\nグループの初期化を行いました。", "OK");
-                            variables.Groups[groupIndex] = new PropGroup();
+                            variables.Groups[groupIndex] = ScriptableObject.CreateInstance<PropGroup>();
                         }
                         else if (variables.Groups[groupIndex].Props == null)
                         {
@@ -267,7 +267,7 @@ namespace YagihataItems.RadialInventorySystemV3
                             if (variables.Groups[groupIndex].Props[propIndex] == null)
                             {
                                 EditorUtility.DisplayDialog("Radial Inventory System", $"グループ{groupIndex}のプロップ{propIndex}が破損していたため、\r\nプロップの初期化を行いました。", "OK");
-                                variables.Groups[groupIndex].Props[propIndex] = new Prop();
+                                variables.Groups[groupIndex].Props[propIndex] = ScriptableObject.CreateInstance<Prop>();
                             }
                             else if(variables.Groups[groupIndex].Props[propIndex].TargetObjects == null)
                             {

--- a/Assets/YagihataItems/RadialInventorySystemV3/Editor/RISMainWindow.cs
+++ b/Assets/YagihataItems/RadialInventorySystemV3/Editor/RISMainWindow.cs
@@ -276,9 +276,12 @@ namespace YagihataItems.RadialInventorySystemV3
                             }
                             // PropはPropGroupのCloneの中でClone済
                             // variables.Groups[groupIndex].Props[propIndex] = (Prop)variables.Groups[groupIndex].Props[propIndex].Clone();
+
+                            GameObject targetObject = null;
+                            // AdvancedModeのTargetObjectsのチェック
                             foreach (var objIndex in Enumerable.Range(0, variables.Groups[groupIndex].Props[propIndex].TargetObjects.Count))
                             {
-                                GameObject targetObject = variables.Groups[groupIndex].Props[propIndex].TargetObjects[objIndex];
+                                targetObject = variables.Groups[groupIndex].Props[propIndex].TargetObjects[objIndex];
                                 if (targetObject != null && !targetObject.IsChildOf(avatarRoot.gameObject))
                                 {
                                     // 指定したavatarRootの子でない場合、元のavatarRootを起点としてパスを取得。
@@ -291,6 +294,22 @@ namespace YagihataItems.RadialInventorySystemV3
                                         variables.Groups[groupIndex].Props[propIndex].TargetObjects[objIndex] = targetObject;
                                     }
                                 }
+                            }
+
+                            // SimpleModeのTargetObjectのチェック
+                            targetObject = variables.Groups[groupIndex].Props[propIndex].TargetObject;
+                            if(targetObject != null && !targetObject.IsChildOf(avatarRoot.gameObject))
+                            {
+                                // 指定したavatarRootの子でない場合、元のavatarRootを起点としてパスを取得。
+                                var objPath = YagiAPI.GetGameObjectPath(targetObject, variables.AvatarRoot.gameObject);
+                                // 指定したavatarRootの子に同じパスのObjectが存在すれば置換。
+                                var targetTransform = avatarRoot.transform.Find(objPath);
+                                if (targetTransform != null)
+                                {
+                                    targetObject = targetTransform.gameObject;
+                                    variables.Groups[groupIndex].Props[propIndex].TargetObject = targetObject;
+                                }
+
                             }
                         }
                     }

--- a/Assets/YagihataItems/RadialInventorySystemV3/Script/Prop.cs
+++ b/Assets/YagihataItems/RadialInventorySystemV3/Script/Prop.cs
@@ -65,9 +65,10 @@ namespace YagihataItems.RadialInventorySystemV3
         public object Clone()
         {
             var obj = ScriptableObject.CreateInstance<Prop>();
+            obj.TargetObject = this.TargetObject;
             obj.IsDefaultEnabled = this.IsDefaultEnabled;
-            obj.PropIcon = this.PropIcon;
             obj.LocalOnly = this.LocalOnly;
+            obj.PropIcon = this.PropIcon;
             obj.EnableAnimation = this.EnableAnimation;
             obj.DisableAnimation = this.DisableAnimation;
             obj.PropName = this.PropName;


### PR DESCRIPTION
異なるインスタンスに対して設定を読み込む場合、Simpleモードの処理が抜けていたので追加しました。